### PR TITLE
Add touch.dispose()

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Returns a vector with the mouse or touch [x, y] on the window. Options:
 - `touchstart` whether to change position on `touchstart` and `mousedown` events as well (default true)
 - `position` the initial position to start with (i.e. before any events are triggered), default is `[0, 0]`
 
-#### `touchPosition.emitter([opt])`
+#### `emitter = touchPosition.emitter([opt])`
 
 The same as above, but returns an `EventEmitter` so you can handle move events:
 
@@ -34,6 +34,16 @@ var touch = require('touch-position').emitter()
 touch.on('move', handleMove)
 
 console.log( touch.position ) // the current [x,y] position
+```
+
+#### `emitter.dispose()`
+
+Removes any attached event listeners from `element` when you no longer need it. After calling this method, `touch.position` will no longer update and the `move` event will stop firing.
+
+```js
+var touch = require('touch-position').emitter()
+
+touch.dispose()
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -11,26 +11,38 @@ function attach(opt) {
     var position = opt.position || [0, 0]
     if (opt.touchstart !== false) {
         addEvent(opt.element, 'mousedown', update)
-        addEvent(opt.element, 'touchstart', function(ev) {
-            var touch = ev.targetTouches[0]
-            update(ev, touch)
-        })
+        addEvent(opt.element, 'touchstart', touchstart)
     }
 
     addEvent(opt.element, 'mousemove', update)
-    addEvent(opt.element, 'touchmove', function(ev) {
-        var touch = ev.targetTouches[0]
-        update(ev, touch)
-    })
+    addEvent(opt.element, 'touchmove', touchmove)
 
     emitter.position = position
+    emitter.dispose = dispose
     return emitter
+
+    function touchstart(ev) {
+        var touch = ev.targetTouches[0]
+        update(ev, touch)
+    }
+
+    function touchmove(ev) {
+        var touch = ev.targetTouches[0]
+        update(ev, touch)
+    }
 
     function update(ev, client) {
         var pos = offset(ev, client)
         position[0] = pos.x
         position[1] = pos.y
         emitter.emit('move', ev)
+    }
+
+    function dispose() {
+        addEvent.removeEventListener(opt.element, 'mousemove', update)
+        addEvent.removeEventListener(opt.element, 'mousedown', update)
+        addEvent.removeEventListener(opt.element, 'touchmove', touchmove)
+        addEvent.removeEventListener(opt.element, 'touchstart', touchstart)
     }
 }
 


### PR DESCRIPTION
This makes it possible to clean up the attached events when they're no longer required.

Thanks! :)
